### PR TITLE
Make test works with latest Rails 7 update

### DIFF
--- a/spec/view_component/form/check_box_component_spec.rb
+++ b/spec/view_component/form/check_box_component_spec.rb
@@ -9,10 +9,11 @@ RSpec.describe ViewComponent::Form::CheckBoxComponent, type: :component do
   let(:component_html_attributes) { component.css("input").last.attributes }
 
   context "with simple args" do
+    it { expect(component.to_html).to have_tag("input", with: { type: "hidden", value: "0", name: "user[admin]" }) }
+
     it do
-      expect(component).to eq_html <<~HTML
-        <input name="user[admin]" type="hidden" value="0"><input type="checkbox" value="1" name="user[admin]" id="user_admin">
-      HTML
+      expect(component.to_html)
+        .to have_tag("input", with: { type: "checkbox", value: "1", name: "user[admin]", id: "user_admin" })
     end
   end
 

--- a/spec/view_component/form/collection_check_boxes_component_spec.rb
+++ b/spec/view_component/form/collection_check_boxes_component_spec.rb
@@ -23,9 +23,33 @@ RSpec.describe ViewComponent::Form::CollectionCheckBoxesComponent, type: :compon
 
   context "with simple args" do
     it do
-      expect(component).to eq_html <<~HTML
-        <input type="hidden" name="user[nationalities][]" value=""><input type="checkbox" value="BE" name="user[nationalities][]" id="user_nationalities_be"><label for="user_nationalities_be">Belgium</label><input type="checkbox" value="FR" name="user[nationalities][]" id="user_nationalities_fr"><label for="user_nationalities_fr">France</label>
-      HTML
+      expect(component.to_html).to have_tag("input", with: { type: "hidden", value: "", name: "user[nationalities][]" })
+    end
+
+    it do
+      expect(component.to_html)
+        .to have_tag("input", with: {
+                       type: "checkbox", value: "BE",
+                       id: "user_nationalities_be", name: "user[nationalities][]"
+                     })
+    end
+
+    it do
+      expect(component.to_html)
+        .to have_tag("input", with: {
+                       type: "checkbox", value: "FR",
+                       id: "user_nationalities_fr", name: "user[nationalities][]"
+                     })
+    end
+
+    it do
+      expect(component.to_html)
+        .to have_tag("label", with: { for: "user_nationalities_be" }, text: "Belgium")
+    end
+
+    it do
+      expect(component.to_html)
+        .to have_tag("label", with: { for: "user_nationalities_fr" }, text: "France")
     end
   end
 

--- a/spec/view_component/form/collection_radio_buttons_component_spec.rb
+++ b/spec/view_component/form/collection_radio_buttons_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ViewComponent::Form::CollectionRadioButtonsComponent, type: :comp
     render_inline(described_class.new(
                     form,
                     object_name,
-                    :nationalities,
+                    :nationality,
                     collection,
                     :code,
                     :name,
@@ -23,9 +23,33 @@ RSpec.describe ViewComponent::Form::CollectionRadioButtonsComponent, type: :comp
 
   context "with simple args" do
     it do
-      expect(component).to eq_html <<~HTML
-        <input type="hidden" name="user[nationalities]" value=""><input type="radio" value="BE" name="user[nationalities]" id="user_nationalities_be"><label for="user_nationalities_be">Belgium</label><input type="radio" value="FR" name="user[nationalities]" id="user_nationalities_fr"><label for="user_nationalities_fr">France</label>
-      HTML
+      expect(component.to_html).to have_tag("input", with: { type: "hidden", value: "", name: "user[nationality]" })
+    end
+
+    it do
+      expect(component.to_html)
+        .to have_tag("input", with: {
+                       type: "radio", value: "BE",
+                       id: "user_nationality_be", name: "user[nationality]"
+                     })
+    end
+
+    it do
+      expect(component.to_html)
+        .to have_tag("input", with: {
+                       type: "radio", value: "FR",
+                       id: "user_nationality_fr", name: "user[nationality]"
+                     })
+    end
+
+    it do
+      expect(component.to_html)
+        .to have_tag("label", with: { for: "user_nationality_be" }, text: "Belgium")
+    end
+
+    it do
+      expect(component.to_html)
+        .to have_tag("label", with: { for: "user_nationality_fr" }, text: "France")
     end
   end
 

--- a/spec/view_component/form/select_component_spec.rb
+++ b/spec/view_component/form/select_component_spec.rb
@@ -41,11 +41,13 @@ RSpec.describe ViewComponent::Form::SelectComponent, type: :component do
   context "with multiple select" do
     let(:html_options) { { multiple: true } }
 
+    it { expect(component.to_html).to have_tag("input", with: { type: "hidden", value: "", name: "user[role][]" }) }
+
     it do
-      expect(component).to eq_html <<~HTML
-        <input name="user[role][]" type="hidden" value=""><select multiple name="user[role][]" id="user_role"><option value="admin">Admin</option>
-        <option value="manager">Manager</option></select>
-      HTML
+      expect(component.to_html).to have_tag("select", with: { name: "user[role][]", id: "user_role" }) do
+        with_tag "option", with: { value: "admin" }, text: "Admin"
+        with_tag "option", with: { value: "manager" }, text: "Manager"
+      end
     end
   end
 


### PR DESCRIPTION
Update tests to use `rspec-html-matchers` and make them works with latest [Rails update](https://github.com/rails/rails/pull/43280)