### PR TITLE
Make it possible to override form tag helper output using a builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 # rspec failure tracking
 .rspec_status
+.byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "appraisal", require: false
+gem "byebug", "~> 11.1", require: false, group: :test
 gem "capybara", require: false
 gem "combustion"
 gem "rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       thor (>= 0.14.0)
     ast (2.4.2)
     builder (3.2.4)
+    byebug (11.1.3)
     capybara (3.35.3)
       addressable
       mini_mime (>= 0.1.3)
@@ -219,6 +220,7 @@ PLATFORMS
 
 DEPENDENCIES
   appraisal
+  byebug (~> 11.1)
   capybara
   combustion
   rails

--- a/app/helpers/view_component/form_tag_helper.rb
+++ b/app/helpers/view_component/form_tag_helper.rb
@@ -1,0 +1,23 @@
+module ViewComponent
+  module FormTagHelper
+    def text_field_tag(name, value = nil, builder: nil, **options)
+      return super if builder.blank?
+
+      builder.mapping.text_field_tag(nil, name, value: value, **options)
+    end
+
+    def label_tag(name = nil, content_or_options = nil, builder: nil, **options, &block)
+      original_tag = super
+      return original_tag if builder.blank?
+      return content_tag :label, content_or_options || name.to_s.humanize, options, &block if builder.blank?
+
+      builder.mapping.label_tag(nil, content_or_options || name.to_s.humanize, **options)
+    end
+
+    def password_field_tag(name = "password", value = nil, builder: nil, **options)
+      return super if builder.blank?
+
+      builder.mapping.password_field_tag(nil, name, value: value, **options)
+    end
+  end
+end

--- a/lib/view_component/form.rb
+++ b/lib/view_component/form.rb
@@ -3,3 +3,4 @@
 require_relative "form/version"
 require_relative "form/engine"
 require_relative "form/builder"
+require_relative "form/component_mapping"

--- a/lib/view_component/form/builder.rb
+++ b/lib/view_component/form/builder.rb
@@ -28,23 +28,14 @@ module ViewComponent
           lookup_namespaces.prepend namespace
         end
 
-        def for_tags
-          Class.new do
-            def method_missing(method_name, *_aargs, **kwargs)
-              render_component(method_name.to_s.delete_suffix("_tag").to_sym, nil, nil, objectify_options(kwargs))
-            rescue NotImplementedComponentError
-              super
-            end
-
-            def respond_to_missing?(method_name, include_private = false)
-              component_klass(method_name.to_s.delete_suffix("_tag").to_sym) || super
-            rescue NotImplementedComponentError
-              super
-            end
-          end
+        def mapping
+          (field_helpers - %i[fields_for phone_field fields hidden_field] + %i[select])
+            .to_h { |selector| [selector, component_klass(selector)] }
         end
 
-        private
+        def for_tags
+          ViewComponent::Form::ComponentMapping.new(mapping)
+        end
 
         def component_klass(component_name)
           component_klass = lookup_namespaces.filter_map do |namespace|

--- a/lib/view_component/form/builder.rb
+++ b/lib/view_component/form/builder.rb
@@ -34,7 +34,7 @@ module ViewComponent
         end
 
         def for_tags
-          ViewComponent::Form::ComponentMapping.new(mapping)
+          ViewComponent::Form::ComponentMapping.new(mapping, @template)
         end
 
         def component_klass(component_name)

--- a/lib/view_component/form/component_mapping.rb
+++ b/lib/view_component/form/component_mapping.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  module Form
+    class ComponentMapping
+      def initialize(mapping)
+        @mapping = HashWithIndifferentAccess.new(mapping)
+      end
+
+      def method_missing(method_name, _args = nil, *_aargs, **_kwargs)
+        @mapping[method_name.to_s.delete_suffix("_tag")]
+      end
+
+      def respond_to_missing?(method_name, include_private = false)
+        @mapping.key?(method_name.to_s.delete_suffix("_tag")) || super
+      end
+    end
+  end
+end

--- a/lib/view_component/form/component_mapping.rb
+++ b/lib/view_component/form/component_mapping.rb
@@ -8,11 +8,17 @@ module ViewComponent
       end
 
       def method_missing(method_name, _args = nil, *_aargs, **_kwargs)
-        @mapping[method_name.to_s.delete_suffix("_tag")]
+        @mapping.fetch(remove_tag_suffix(method_name))
       end
 
       def respond_to_missing?(method_name, include_private = false)
-        @mapping.key?(method_name.to_s.delete_suffix("_tag")) || super
+        @mapping.key?(remove_tag_suffix(method_name)) || super
+      end
+
+      private
+
+      def remove_tag_suffix(method_name)
+        method_name.to_s.delete_suffix("_tag")
       end
     end
   end

--- a/lib/view_component/form/component_mapping.rb
+++ b/lib/view_component/form/component_mapping.rb
@@ -3,12 +3,15 @@
 module ViewComponent
   module Form
     class ComponentMapping
-      def initialize(mapping)
+      def initialize(mapping, template)
         @mapping = HashWithIndifferentAccess.new(mapping)
+        @template = template
       end
 
-      def method_missing(method_name, _args = nil, *_aargs, **_kwargs)
+      def method_missing(method_name, field_name = nil, *aargs, **kwargs)
         @mapping.fetch(remove_tag_suffix(method_name))
+                .new(nil, field_name, *aargs, **kwargs)
+                .render_in(@template, &block)
       end
 
       def respond_to_missing?(method_name, include_private = false)

--- a/spec/view_component/form/builder_spec.rb
+++ b/spec/view_component/form/builder_spec.rb
@@ -69,4 +69,35 @@ RSpec.describe ViewComponent::Form::Builder, type: :builder do
       it { expect(builder.send(:component_klass, :submit)).to eq(ViewComponent::Form::SubmitComponent) }
     end
   end
+
+  describe "#for_tags" do
+    subject { described_class.for_tags }
+
+    it { is_expected.to respond_to(:select_tag).with(1..3).arguments }
+    it { is_expected.to respond_to(:text_field_tag).with(1..3).arguments }
+    it { is_expected.to respond_to(:label_tag).with(0..3).arguments }
+    it { is_expected.to respond_to(:hidden_field_tag).with(1..3).arguments }
+    it { is_expected.to respond_to(:file_field_tag).with(1..2).arguments }
+    it { is_expected.to respond_to(:password_field_tag).with(0..3).arguments }
+    it { is_expected.to respond_to(:text_area_tag).with(1..3).arguments }
+    it { is_expected.to respond_to(:check_box_tag).with(1..4).arguments }
+    it { is_expected.to respond_to(:radio_button_tag).with(2..4).arguments }
+    it { is_expected.to respond_to(:submit_tag).with(0..2).arguments }
+    it { is_expected.to respond_to(:button_tag).with(0..2).arguments }
+    it { is_expected.to respond_to(:image_submit_tag).with(0..2).arguments }
+    it { is_expected.to respond_to(:field_set_tag).with(0..2).arguments }
+    it { is_expected.to respond_to(:color_field_tag).with(1..3).arguments }
+    it { is_expected.to respond_to(:search_field_tag).with(1..3).arguments }
+    it { is_expected.to respond_to(:telephone_field_tag).with(1..3).arguments }
+    it { is_expected.to respond_to(:date_field_tag).with(1..3).arguments }
+    it { is_expected.to respond_to(:time_field_tag).with(1..3).arguments }
+    it { is_expected.to respond_to(:datetime_field_tag).with(1..3).arguments }
+    it { is_expected.to respond_to(:datetime_local_field_tag).with(1..3).arguments }
+    it { is_expected.to respond_to(:month_field_tag).with(1..3).arguments }
+    it { is_expected.to respond_to(:week_field_tag).with(1..3).arguments }
+    it { is_expected.to respond_to(:url_field_tag).with(1..3).arguments }
+    it { is_expected.to respond_to(:email_field_tag).with(1..3).arguments }
+    it { is_expected.to respond_to(:number_field_tag).with(1..3).arguments }
+    it { is_expected.to respond_to(:range_field_tag).with(1..3).arguments }
+  end
 end


### PR DESCRIPTION
Closes #81 

The aim of this PR will be to make it so that you can pass a form builder class to a tag helper to render the corresponding component. For example:

```ruby
text_field_tag 'name', 'Simon', builder: ViewComponent::Form::Builder.for_tag
```

will call `text_field` on `ViewComponent::Form::Builder.for_tag` and pass the arguments correctly in order to render `ViewComponent::Form::TextFieldComponent`.