### PR TITLE
refactor: make Base and FieldComponent support form without object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cross-documented Rails form helpers (#84)
 - Made tag_klass optional when inheriting from a component class (#87)
 - Add rails 7.0 and make rails head works (#94)
+- Allow `Base` and `FieldComponent` to support forms without objects (#95)
 
 ### Fixed
 - Fix `phone_field` helper (#74)

--- a/app/components/view_component/form/base_component.rb
+++ b/app/components/view_component/form/base_component.rb
@@ -14,8 +14,8 @@ module ViewComponent
 
       attr_reader :form, :object_name, :options
 
-      delegate :object, to: :form
-      delegate :errors, to: :object, prefix: true
+      delegate :object, to: :form, allow_nil: true
+      delegate :errors, to: :object, prefix: true, allow_nil: true
 
       def initialize(form, object_name, options = {})
         @form = form
@@ -28,6 +28,8 @@ module ViewComponent
       end
 
       def object_errors?
+        return false unless object
+
         object.errors.any?
       end
 

--- a/app/components/view_component/form/field_component.rb
+++ b/app/components/view_component/form/field_component.rb
@@ -32,10 +32,14 @@ module ViewComponent
 
       if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new("6.1")
         def method_errors?
+          return false unless object_errors
+
           (object_errors.attribute_names & object_method_names).any?
         end
       else
         def method_errors?
+          return false unless object_errors
+
           (object_errors.keys & object_method_names).any?
         end
       end

--- a/lib/view_component/form/builder.rb
+++ b/lib/view_component/form/builder.rb
@@ -107,18 +107,6 @@ module ViewComponent
         render_component(:button, value, options, &block)
       end
 
-      # SELECTORS.each do |selector|
-      #   class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
-      #     def #{selector}(*args)
-      #       render_component(
-      #         :#{selector},
-      #         *args,
-      #         super,
-      #       )
-      #     end
-      #   RUBY_EVAL
-      # end
-
       # See: https://github.com/rails/rails/blob/fe76a95b0d252a2d7c25e69498b720c96b243ea2/actionview/lib/action_view/helpers/form_options_helper.rb
       def select(method, choices = nil, options = {}, html_options = {}, &block)
         render_component(

--- a/spec/view_component/form/base_component_spec.rb
+++ b/spec/view_component/form/base_component_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe ViewComponent::Form::BaseComponent, type: :component do
   let(:component) { described_class.new(form, object_name, options) }
 
   describe "#object_errors?" do
-    before { object.validate }
-
     context "with valid object" do
       let(:object) { object_klass.new(first_name: "John") }
+
+      before { object.validate }
 
       it { expect(component.object_errors?).to eq(false) }
     end
@@ -35,7 +35,15 @@ RSpec.describe ViewComponent::Form::BaseComponent, type: :component do
     context "with invalid object" do
       let(:object) { object_klass.new(first_name: "") }
 
+      before { object.validate }
+
       it { expect(component.object_errors?).to eq(true) }
+    end
+
+    context "without object" do
+      let(:object) { nil }
+
+      it { expect(component.object_errors?).to eq(false) }
     end
   end
 end

--- a/spec/view_component/form/field_component_spec.rb
+++ b/spec/view_component/form/field_component_spec.rb
@@ -36,10 +36,10 @@ RSpec.describe ViewComponent::Form::FieldComponent, type: :component do
   end
 
   describe "#method_errors" do
-    before { object.validate }
-
     context "with valid object" do
       let(:object) { object_klass.new(first_name: "John") }
+
+      before { object.validate }
 
       it { expect(component.method_errors).to eq([]) }
     end
@@ -47,15 +47,23 @@ RSpec.describe ViewComponent::Form::FieldComponent, type: :component do
     context "with invalid object" do
       let(:object) { object_klass.new(first_name: "") }
 
+      before { object.validate }
+
       it { expect(component.method_errors).to eq(["Can't be blank", "Is too short (minimum is 2 characters)"]) }
+    end
+
+    context "without object" do
+      let(:object) { nil }
+
+      it { expect(component.method_errors).to eq([]) }
     end
   end
 
   describe "#method_errors?" do
-    before { object.validate }
-
     context "with valid object" do
       let(:object) { object_klass.new(first_name: "John") }
+
+      before { object.validate }
 
       it { expect(component.method_errors?).to eq(false) }
     end
@@ -63,7 +71,15 @@ RSpec.describe ViewComponent::Form::FieldComponent, type: :component do
     context "with invalid object" do
       let(:object) { object_klass.new(first_name: "") }
 
+      before { object.validate }
+
       it { expect(component.method_errors?).to eq(true) }
+    end
+
+    context "without object" do
+      let(:object) { nil }
+
+      it { expect(component.method_errors?).to eq(false) }
     end
   end
 


### PR DESCRIPTION
This make `BaseComponent` and `FieldComponent` works with form that use `#object_errors?`, `#method_errors` or `#method_errors?` method and have form without objects.