### PR TITLE
Add HintComponent and ErrorMessageComponent

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Then call your helpers as usual:
 
   <%= f.label :password %>          <%# renders a ViewComponent::Form::LabelComponent %>
   <%= f.password_field :password %> <%# renders a ViewComponent::Form::PasswordFieldComponent %>
+  <%= f.hint :password, 'The password should be at least 8 characters long' %>
+                                    <%# renders a ViewComponent::Form::HintComponent %>
+  <%= f.error_message :password %>  <%# renders a ViewComponent::Form::ErrorMessageComponent %>
 <% end %>
 ```
 
@@ -70,6 +73,7 @@ It should work out of the box, but does nothing particularly interesting for now
 
   <label for="user_password">Password</label>
   <input type="password" name="user[password]" id="user_password" />
+  <div>The password should be at least 8 characters long</div>
 </form>
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Then call your helpers as usual:
   <%= f.email_field :email %>       <%# renders a ViewComponent::Form::EmailFieldComponent %>
 
   <%= f.label :password %>          <%# renders a ViewComponent::Form::LabelComponent %>
-  <%= f.password_field :password, aria: { describedby: f.field_id(: password, :description) } %>
+  <%= f.password_field :password, aria: { describedby: f.field_id(:password, :description) } %>
                                     <%# renders a ViewComponent::Form::PasswordFieldComponent %>
                                     <%# Note: #field_id only supported on Rails 7 %>
   <div id="<%= f.field_id(:title, :description) %>">

--- a/README.md
+++ b/README.md
@@ -48,10 +48,14 @@ Then call your helpers as usual:
   <%= f.email_field :email %>       <%# renders a ViewComponent::Form::EmailFieldComponent %>
 
   <%= f.label :password %>          <%# renders a ViewComponent::Form::LabelComponent %>
-  <%= f.password_field :password %> <%# renders a ViewComponent::Form::PasswordFieldComponent %>
-  <%= f.hint :password, 'The password should be at least 8 characters long' %>
-                                    <%# renders a ViewComponent::Form::HintComponent %>
-  <%= f.error_message :password %>  <%# renders a ViewComponent::Form::ErrorMessageComponent %>
+  <%= f.password_field :password, aria: { describedby: f.field_id(: password, :description) } %>
+                                    <%# renders a ViewComponent::Form::PasswordFieldComponent %>
+                                    <%# Note: #field_id only supported on Rails 7 %>
+  <div id="<%= f.field_id(:title, :description) %>">
+    <%= f.hint :password, 'The password should be at least 8 characters long' %>
+                                      <%# renders a ViewComponent::Form::HintComponent %>
+    <%= f.error_message :password %>  <%# renders a ViewComponent::Form::ErrorMessageComponent %>
+  </div>
 <% end %>
 ```
 
@@ -72,8 +76,10 @@ It should work out of the box, but does nothing particularly interesting for now
   <input type="email" value="john.doe@example.com" name="user[email]" id="user_email" />
 
   <label for="user_password">Password</label>
-  <input type="password" name="user[password]" id="user_password" />
-  <div>The password should be at least 8 characters long</div>
+  <input type="password" name="user[password]" id="user_password" aria-describedby="user_password_description" />
+  <div id="user_password_description">
+    <div>The password should be at least 8 characters long</div>
+  </div>
 </form>
 ```
 

--- a/app/components/view_component/form/error_message_component.rb
+++ b/app/components/view_component/form/error_message_component.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  module Form
+    class ErrorMessageComponent < FieldComponent
+      class_attribute :tag, instance_reader: false, instance_writer: false, instance_accessor: false,
+                            instance_predicate: false
+
+      self.tag = :div
+
+      def call
+        tag.public_send(self.class.tag, messages, options)
+      end
+
+      def render?
+        method_errors?
+      end
+
+      def messages
+        safe_join(method_errors, tag.br)
+      end
+    end
+  end
+end

--- a/app/components/view_component/form/error_message_component.rb
+++ b/app/components/view_component/form/error_message_component.rb
@@ -9,7 +9,7 @@ module ViewComponent
       self.tag = :div
 
       def call
-        tag.public_send(self.class.tag, messages, options)
+        tag.public_send(self.class.tag, messages, **options)
       end
 
       def render?

--- a/app/components/view_component/form/hint_component.rb
+++ b/app/components/view_component/form/hint_component.rb
@@ -28,7 +28,7 @@ module ViewComponent
 
         content_or_options = content || attribute_content if content.present? || attribute_content.present?
 
-        tag.public_send(self.class.tag, content_or_options, options)
+        tag.public_send(self.class.tag, content_or_options, **options)
       end
 
       def render?

--- a/app/components/view_component/form/hint_component.rb
+++ b/app/components/view_component/form/hint_component.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  module Form
+    class HintComponent < FieldComponent
+      class_attribute :tag, instance_reader: false, instance_writer: false, instance_accessor: false,
+                            instance_predicate: false
+      attr_reader :attribute_content
+
+      self.tag = :div
+
+      def initialize(form, object_name, method_name, content_or_options = nil, options = nil)
+        options ||= {}
+
+        content_is_options = content_or_options.is_a?(Hash)
+        if content_is_options
+          options.merge! content_or_options
+          @attribute_content = nil
+        else
+          @attribute_content = content_or_options
+        end
+
+        super(form, object_name, method_name, options)
+      end
+
+      def call
+        content_or_options = nil
+
+        content_or_options = content || attribute_content if content.present? || attribute_content.present?
+
+        tag.public_send(self.class.tag, messages, options)
+      end
+
+      def render?
+        content.present? || attribute_content.present?
+      end
+    end
+  end
+end

--- a/app/components/view_component/form/hint_component.rb
+++ b/app/components/view_component/form/hint_component.rb
@@ -24,9 +24,7 @@ module ViewComponent
       end
 
       def call
-        content_or_options = nil
-
-        content_or_options = content || attribute_content if content.present? || attribute_content.present?
+        content_or_options = content.presence || attribute_content.presence
 
         tag.public_send(self.class.tag, content_or_options, **options)
       end

--- a/app/components/view_component/form/hint_component.rb
+++ b/app/components/view_component/form/hint_component.rb
@@ -28,7 +28,7 @@ module ViewComponent
 
         content_or_options = content || attribute_content if content.present? || attribute_content.present?
 
-        tag.public_send(self.class.tag, messages, options)
+        tag.public_send(self.class.tag, content_or_options, options)
       end
 
       def render?

--- a/lib/view_component/form/builder.rb
+++ b/lib/view_component/form/builder.rb
@@ -189,6 +189,14 @@ module ViewComponent
         end
       end
 
+      def error_message(method, options = {})
+        render_component(:error_message, @object_name, method, objectify_options(options))
+      end
+
+      def hint(method, text = nil, options = {}, &block)
+        render_component(:hint, @object_name, method, text, objectify_options(options), &block)
+      end
+
       private
 
       def render_component(component_name, *args, &block)

--- a/spec/view_component/form/error_message_component_spec.rb
+++ b/spec/view_component/form/error_message_component_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe ViewComponent::Form::ErrorMessageComponent, type: :component do
   let(:component_html_attributes) { rendered_component.css("div").first.attributes }
 
   context "with valid object" do
+    subject { component }
     let(:object) { object_klass.new(first_name: "John") }
 
     before { object.validate }
 
-    it { expect(component.method_errors).to eq([]) }
-    it { expect(component.render?).to be false }
+    it { is_expected.to have_attributes(method_errors: [], render?: false) }
   end
 
   context "with invalid object" do

--- a/spec/view_component/form/error_message_component_spec.rb
+++ b/spec/view_component/form/error_message_component_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe ViewComponent::Form::ErrorMessageComponent, type: :component do
       it { expect(component.method_errors).to eq(["Can't be blank", "Is too short (minimum is 2 characters)"]) }
       it { expect(component.render?).to be true }
 
-      it { is_expected.to eq_html '<div>Can't be blank<br>Is too short (minimum is 2 characters)</div>' }
+      it { is_expected.to eq_html "<div>Can't be blank<br>Is too short (minimum is 2 characters)</div>" }
     end
 
     include_examples "component with custom html classes"

--- a/spec/view_component/form/error_message_component_spec.rb
+++ b/spec/view_component/form/error_message_component_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe ViewComponent::Form::ErrorMessageComponent, type: :component do
     context "with simple args" do
       it { expect(subject.method_errors).to eq(["Can't be blank", "Is too short (minimum is 2 characters)"]) }
       it { expect(subject.render?).to be true }
+
       it do
         expect(component).to eq_html <<~HTML
           <div>Can't be blank<br>Is too short (minimum is 2 characters)</div>

--- a/spec/view_component/form/error_message_component_spec.rb
+++ b/spec/view_component/form/error_message_component_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe ViewComponent::Form::ErrorMessageComponent, type: :component do
   subject(:rendered_component) { render_inline(component) }
+
   let(:component) { described_class.new(form, object_name, :first_name, options) }
 
   let(:object_klass) do
@@ -27,6 +28,7 @@ RSpec.describe ViewComponent::Form::ErrorMessageComponent, type: :component do
 
   context "with valid object" do
     subject { component }
+
     let(:object) { object_klass.new(first_name: "John") }
 
     before { object.validate }

--- a/spec/view_component/form/error_message_component_spec.rb
+++ b/spec/view_component/form/error_message_component_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+RSpec.describe ViewComponent::Form::ErrorMessageComponent, type: :component do
+  subject { described_class.new(form, object_name, :first_name, options) }
+
+  let(:object_klass) do
+    Class.new do
+      include ActiveModel::Model
+
+      attr_accessor :first_name
+
+      validates :first_name, presence: true, length: { minimum: 2 }
+
+      class << self
+        def name
+          "User"
+        end
+      end
+    end
+  end
+
+  let(:object)  { object_klass.new }
+  let(:form)    { form_with(object) }
+  let(:options) { {} }
+
+  let(:component) { render_inline(subject) }
+  let(:component_html_attributes) { component.css("div").first.attributes }
+
+  context "with valid object" do
+    let(:object) { object_klass.new(first_name: "John") }
+
+    before { object.validate }
+
+    it { expect(subject.method_errors).to eq([]) }
+    it { expect(subject.render?).to be false }
+  end
+
+  context "with invalid object" do
+    context "with simple args" do
+      let(:object) { object_klass.new(first_name: "") }
+
+      before { object.validate }
+
+      it { expect(subject.method_errors).to eq(["Can't be blank", "Is too short (minimum is 2 characters)"]) }
+      it { expect(subject.render?).to be true }
+      it do
+        expect(component).to eq_html <<~HTML
+          <div>Can't be blank<br>Is too short (minimum is 2 characters)</div>
+        HTML
+      end
+    end
+
+
+    include_examples "component with custom html classes"
+    include_examples "component with custom data attributes"
+  end
+end

--- a/spec/view_component/form/error_message_component_spec.rb
+++ b/spec/view_component/form/error_message_component_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe ViewComponent::Form::ErrorMessageComponent, type: :component do
-  subject { described_class.new(form, object_name, :first_name, options) }
+  subject(:component) { described_class.new(form, object_name, :first_name, options) }
 
   let(:object_klass) do
     Class.new do
@@ -23,16 +23,16 @@ RSpec.describe ViewComponent::Form::ErrorMessageComponent, type: :component do
   let(:form)    { form_with(object) }
   let(:options) { {} }
 
-  let(:component) { render_inline(subject) }
-  let(:component_html_attributes) { component.css("div").first.attributes }
+  let(:rendered_component) { render_inline(component) }
+  let(:component_html_attributes) { rendered_component.css("div").first.attributes }
 
   context "with valid object" do
     let(:object) { object_klass.new(first_name: "John") }
 
     before { object.validate }
 
-    it { expect(subject.method_errors).to eq([]) }
-    it { expect(subject.render?).to be false }
+    it { expect(component.method_errors).to eq([]) }
+    it { expect(component.render?).to be false }
   end
 
   context "with invalid object" do
@@ -41,11 +41,11 @@ RSpec.describe ViewComponent::Form::ErrorMessageComponent, type: :component do
     before { object.validate }
 
     context "with simple args" do
-      it { expect(subject.method_errors).to eq(["Can't be blank", "Is too short (minimum is 2 characters)"]) }
-      it { expect(subject.render?).to be true }
+      it { expect(component.method_errors).to eq(["Can't be blank", "Is too short (minimum is 2 characters)"]) }
+      it { expect(component.render?).to be true }
 
       it do
-        expect(component).to eq_html <<~HTML
+        expect(rendered_component).to eq_html <<~HTML
           <div>Can't be blank<br>Is too short (minimum is 2 characters)</div>
         HTML
       end

--- a/spec/view_component/form/error_message_component_spec.rb
+++ b/spec/view_component/form/error_message_component_spec.rb
@@ -43,11 +43,7 @@ RSpec.describe ViewComponent::Form::ErrorMessageComponent, type: :component do
       it { expect(component.method_errors).to eq(["Can't be blank", "Is too short (minimum is 2 characters)"]) }
       it { expect(component.render?).to be true }
 
-      it do
-        expect(rendered_component).to eq_html <<~HTML
-          <div>Can't be blank<br>Is too short (minimum is 2 characters)</div>
-        HTML
-      end
+      it { is_expected.to eq_html '<div>Can't be blank<br>Is too short (minimum is 2 characters)</div>' }
     end
 
     include_examples "component with custom html classes"

--- a/spec/view_component/form/error_message_component_spec.rb
+++ b/spec/view_component/form/error_message_component_spec.rb
@@ -36,11 +36,11 @@ RSpec.describe ViewComponent::Form::ErrorMessageComponent, type: :component do
   end
 
   context "with invalid object" do
+    let(:object) { object_klass.new(first_name: "") }
+
+    before { object.validate }
+
     context "with simple args" do
-      let(:object) { object_klass.new(first_name: "") }
-
-      before { object.validate }
-
       it { expect(subject.method_errors).to eq(["Can't be blank", "Is too short (minimum is 2 characters)"]) }
       it { expect(subject.render?).to be true }
       it do
@@ -49,7 +49,6 @@ RSpec.describe ViewComponent::Form::ErrorMessageComponent, type: :component do
         HTML
       end
     end
-
 
     include_examples "component with custom html classes"
     include_examples "component with custom data attributes"

--- a/spec/view_component/form/error_message_component_spec.rb
+++ b/spec/view_component/form/error_message_component_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe ViewComponent::Form::ErrorMessageComponent, type: :component do
-  subject(:component) { described_class.new(form, object_name, :first_name, options) }
+  subject(:rendered_component) { render_inline(component) }
+  let(:component) { described_class.new(form, object_name, :first_name, options) }
 
   let(:object_klass) do
     Class.new do
@@ -22,8 +23,6 @@ RSpec.describe ViewComponent::Form::ErrorMessageComponent, type: :component do
   let(:object)  { object_klass.new }
   let(:form)    { form_with(object) }
   let(:options) { {} }
-
-  let(:rendered_component) { render_inline(component) }
   let(:component_html_attributes) { rendered_component.css("div").first.attributes }
 
   context "with valid object" do

--- a/spec/view_component/form/hint_component_spec.rb
+++ b/spec/view_component/form/hint_component_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe ViewComponent::Form::HintComponent, type: :component do
-  subject { described_class.new(form, object_name, :birth_date, 'this is my hint for you', options) }
+  subject { described_class.new(form, object_name, :birth_date, "this is my hint for you", options) }
 
   let(:object)  { OpenStruct.new }
   let(:form)    { form_with(object) }

--- a/spec/view_component/form/hint_component_spec.rb
+++ b/spec/view_component/form/hint_component_spec.rb
@@ -1,21 +1,16 @@
 # frozen_string_literal: true
 
 RSpec.describe ViewComponent::Form::HintComponent, type: :component do
-  subject { described_class.new(form, object_name, :birth_date, "this is my hint for you", options) }
-
+  subject(:rendered_component) { render_inline(component) }
+  
+  let(:component) { described_class.new(form, object_name, :birth_date, "this is my hint for you", options) }
   let(:object)  { OpenStruct.new }
   let(:form)    { form_with(object) }
   let(:options) { {} }
-
-  let(:component) { render_inline(subject) }
   let(:component_html_attributes) { component.css("div").first.attributes }
 
   context "with simple args" do
-    it do
-      expect(component).to eq_html <<~HTML
-        <div>this is my hint for you</div>
-      HTML
-    end
+    it { is_expected.to eq_html '<div>this is my hint for you</div>' }
   end
 
   include_examples "component with custom html classes"

--- a/spec/view_component/form/hint_component_spec.rb
+++ b/spec/view_component/form/hint_component_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe ViewComponent::Form::HintComponent, type: :component do
+  let(:object)  { OpenStruct.new }
+  let(:form)    { form_with(object) }
+  let(:options) { {} }
+
+  let(:component) { render_inline(described_class.new(form, object_name, :birth_date, 'this is my hint for you', options)) }
+  let(:component_html_attributes) { component.css("div").first.attributes }
+
+  context "with simple args" do
+    it do
+      expect(component).to eq_html <<~HTML
+        <div>this is my hint for you</div>
+      HTML
+    end
+  end
+
+  include_examples "component with custom html classes"
+  include_examples "component with custom data attributes"
+  include_examples "component with custom value"
+end

--- a/spec/view_component/form/hint_component_spec.rb
+++ b/spec/view_component/form/hint_component_spec.rb
@@ -2,15 +2,15 @@
 
 RSpec.describe ViewComponent::Form::HintComponent, type: :component do
   subject(:rendered_component) { render_inline(component) }
-  
+
   let(:component) { described_class.new(form, object_name, :birth_date, "this is my hint for you", options) }
   let(:object)  { OpenStruct.new }
   let(:form)    { form_with(object) }
   let(:options) { {} }
-  let(:component_html_attributes) { component.css("div").first.attributes }
+  let(:component_html_attributes) { rendered_component.css("div").first.attributes }
 
   context "with simple args" do
-    it { is_expected.to eq_html '<div>this is my hint for you</div>' }
+    it { is_expected.to eq_html "<div>this is my hint for you</div>" }
   end
 
   include_examples "component with custom html classes"

--- a/spec/view_component/form/hint_component_spec.rb
+++ b/spec/view_component/form/hint_component_spec.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe ViewComponent::Form::HintComponent, type: :component do
+  subject { described_class.new(form, object_name, :birth_date, 'this is my hint for you', options) }
+
   let(:object)  { OpenStruct.new }
   let(:form)    { form_with(object) }
   let(:options) { {} }
 
-  let(:component) { render_inline(described_class.new(form, object_name, :birth_date, 'this is my hint for you', options)) }
+  let(:component) { render_inline(subject) }
   let(:component_html_attributes) { component.css("div").first.attributes }
 
   context "with simple args" do


### PR DESCRIPTION
Closes #97 

This is a Pull Request to add components for hints and error messages, as proposed in #36 

I introduce here a class attribute called `tag`. `tag_class` was not really a good fit for this use case.
Please see, if this fits your idea for the gem.

Note: For some reason of my local setup, I was unable to test this at all. I hope the CI pipeline provides some insights :)

## Open Topics

- [x] Ensure enough tests exist and the pass
- [x] Get alignment on `.class` class attribute
- [x] (idea) Generate ID attribute and show how to use it with [`aria-describedby `](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute). I think Rails 6.1 or 7.0 introduced a convenient helper for this. I am just unsure how it was called...
   - [`#dom_id `](https://api.rubyonrails.org/classes/ActionView/RecordIdentifier.html#method-i-dom_id)
   - sanitize_to_id
   - [`#field_id`](https://github.com/rails/rails/blob/6bfc637659248df5d6719a86d2981b52662d9b50/actionview/lib/action_view/helpers/form_helper.rb#L1736-L1754)