### PR TITLE
Initialize empty RichTextAreaComponent if ActionText not installed, to fix Zeitwerk error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-Nothing yet
+### Fixed
+- Declare empty RichTextAreaComponent if ActionText is not installed, to fix Zeitwerk error (#120)
 
 ## [0.2.2] - 2022-03-23
 ### Changed

--- a/app/components/view_component/form/rich_text_area_component.rb
+++ b/app/components/view_component/form/rich_text_area_component.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-if defined?(ActionView::Helpers::Tags::ActionText)
-  module ViewComponent
-    module Form
-      class RichTextAreaComponent < FieldComponent
+module ViewComponent
+  module Form
+    class RichTextAreaComponent < FieldComponent
+      if defined?(ActionView::Helpers::Tags::ActionText) # rubocop:disable Style/IfUnlessModifier
         self.tag_klass = ActionView::Helpers::Tags::ActionText
       end
     end


### PR DESCRIPTION
Closes #119 