### PR TITLE
Fix file field direct upload option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Add ruby 3.1 to CI (#123) 
 
+### Fixed
+- Fix `FileFieldComponent` options for `direct_upload` and `include_hidden` (#122)
+
 ## [0.2.3] - 2022-03-24
 ### Fixed
 - Declare empty RichTextAreaComponent if ActionText is not installed, to fix Zeitwerk error (#120)

--- a/app/components/view_component/form/file_field_component.rb
+++ b/app/components/view_component/form/file_field_component.rb
@@ -4,6 +4,15 @@ module ViewComponent
   module Form
     class FileFieldComponent < FieldComponent
       self.tag_klass = ActionView::Helpers::Tags::FileField
+
+      def before_render
+        if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new("7.0")
+          @options = { include_hidden: multiple_file_field_include_hidden }.merge!(options)
+        end
+        @options = convert_direct_upload_option_to_url(@options.dup)
+
+        super
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ require "combustion"
 
 Combustion.path = "spec/internal"
 
-modules = %i[action_controller action_view active_record]
+modules = %i[action_controller action_view active_record active_storage]
 modules << :action_text if ENV.fetch("VIEW_COMPONENT_FORM_USE_ACTIONTEXT", "false") == "true"
 
 Combustion.initialize!(*modules) do

--- a/spec/view_component/form/file_field_component_spec.rb
+++ b/spec/view_component/form/file_field_component_spec.rb
@@ -16,6 +16,28 @@ RSpec.describe ViewComponent::Form::FileFieldComponent, type: :component do
     end
   end
 
+  context "with direct upload" do
+    let(:options) { { direct_upload: true } }
+
+    it do
+      expect(component).to eq_html <<~HTML
+        <input data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" type="file" name="user[avatar]" id="user_avatar">
+      HTML
+    end
+  end
+
+  if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new("7.0")
+    context "with multiple and include hidden" do
+      let(:options) { { multiple: true, include_hidden: true } }
+
+      it do
+        expect(component).to eq_html <<~HTML
+          <input name="user[avatar][]" type="hidden" value="" autocomplete="off"><input multiple type="file" name="user[avatar][]" id="user_avatar">
+        HTML
+      end
+    end
+  end
+
   include_examples "component with custom html classes"
   include_examples "component with custom data attributes"
 end


### PR DESCRIPTION
The `file_field` helper converts the `direct_upload` option to a data attribute: https://github.com/rails/rails/blob/main/actionview/lib/action_view/helpers/form_helper.rb#L1242

This change would make this example from the rails guide (found [here](https://edgeguides.rubyonrails.org/active_storage_overview.html#direct-uploads)) work:
```
<%= form.file_field :attachments, multiple: true, direct_upload: true %>
```

There may be a better alternative to `before_render`, I wasn't sure the best place to put it. `#initialize` won't work since we need helpers to be accessible.