### PR TITLE
Add missing block arg for fields

### DIFF
--- a/lib/view_component/form/helpers/rails.rb
+++ b/lib/view_component/form/helpers/rails.rb
@@ -21,14 +21,15 @@ module ViewComponent
               radio_button
             ]).each do |selector|
               class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
-                def #{selector}(method, options = {}) # def text_field(method, options = {})
-                  render_component(                   #   render_component(
-                    :#{selector},                     #     :text_field,
-                    @object_name,                     #     @object_name,
-                    method,                           #     method,
-                    objectify_options(options),       #     objectify_options(options),
-                  )                                   #   )
-                end                                   # end
+                def #{selector}(method, options = {}, &block) # def text_field(method, options = {})
+                  render_component(                           #   render_component(
+                    :#{selector},                             #     :text_field,
+                    @object_name,                             #     @object_name,
+                    method,                                   #     method,
+                    objectify_options(options),               #     objectify_options(options),
+                    &block                                    #     &block,
+                  )                                           #   )
+                end                                           # end
               RUBY_EVAL
             end
             alias_method :phone_field, :telephone_field


### PR DESCRIPTION
The dynamic methods created by the form helper are missing the block param which makes it impossible to render slots in custom components.

Does this need a bit of test coverage before it can go in?