### PR TITLE
Add gem configuration, with base component customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added parent_component configuration for field components (#160)
+
 ## [0.2.6] - 2023-10-11
 ### Added
 - Support for Rails 7.1 (#151)

--- a/README.md
+++ b/README.md
@@ -194,6 +194,12 @@ You can use the same approach to inject options, wrap the input in a `<div>`, et
 
 We'll add more use cases to the documentation soon.
 
+### Configuration
+
+| Attribute          | Purpose                                         | Default               |
+| ------------------ | ----------------------------------------------- | --------------------- |
+| `parent_component` | Inherited by all ViewComponent::Form components | `ViewComponent::Base` |
+
 ### Building your own components
 
 When building your own ViewComponents for using in forms, it's recommended to inherit from `ViewComponent::Form::FieldComponent`, so you get access to the following helpers:
@@ -336,6 +342,33 @@ Alternatively, you can pass the context to the helpers:
 ```rb
 def length_validator
   validators(context: :registration).find { |v| v.is_a?(ActiveModel::Validations::LengthValidator) }
+end
+```
+
+### Setting up your own base component class
+
+1. Setup some base component from which the form components will inherit from
+```rb
+class ApplicationFormComponent < ViewComponent::Base
+  include Heroicon::Engine.helpers
+
+  alias_method :icon, :heroicon
+
+  def html_class
+    class_names(
+      "block w-full rounded-md border-0 py-1.5 ring-1 ring-inset focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6",
+      "text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-indigo-600",
+      "pr-10 text-red-900 ring-red-300 placeholder:text-red-300 focus:ring-red-500": method_errors?,
+    )
+  end
+end
+```
+2. Configure the parent component class
+```rb
+# config/initializers/vcf.rb
+
+ViewComponent::Form.configure do |config|
+  config.parent_component = 'ApplicationFormComponent'
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ We'll add more use cases to the documentation soon.
 
 | Attribute          | Purpose                                         | Default               |
 | ------------------ | ----------------------------------------------- | --------------------- |
-| `parent_component` | Inherited by all ViewComponent::Form components | `ViewComponent::Base` |
+| `parent_component` (string) | Parent class for all `ViewComponent::Form` components | `"ViewComponent::Base"` |
 
 ### Building your own components
 

--- a/README.md
+++ b/README.md
@@ -350,17 +350,6 @@ end
 1. Setup some base component from which the form components will inherit from
 ```rb
 class ApplicationFormComponent < ViewComponent::Base
-  include Heroicon::Engine.helpers
-
-  alias_method :icon, :heroicon
-
-  def html_class
-    class_names(
-      "block w-full rounded-md border-0 py-1.5 ring-1 ring-inset focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6",
-      "text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-indigo-600",
-      "pr-10 text-red-900 ring-red-300 placeholder:text-red-300 focus:ring-red-500": method_errors?,
-    )
-  end
 end
 ```
 2. Configure the parent component class

--- a/app/components/view_component/form/base_component.rb
+++ b/app/components/view_component/form/base_component.rb
@@ -2,7 +2,7 @@
 
 module ViewComponent
   module Form
-    class BaseComponent < ViewComponent::Base
+    class BaseComponent < ViewComponent::Form.configuration.parent_component.constantize
       class << self
         attr_accessor :default_options
       end

--- a/lib/view_component/form.rb
+++ b/lib/view_component/form.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "view_component"
-require_relative "form/configuration"
 require "zeitwerk"
 
 module ViewComponent

--- a/lib/view_component/form.rb
+++ b/lib/view_component/form.rb
@@ -1,10 +1,20 @@
 # frozen_string_literal: true
 
 require "view_component"
+require_relative "form/configuration"
 require "zeitwerk"
 
 module ViewComponent
   module Form
+    class << self
+      def configuration
+        @configuration ||= Configuration.new
+      end
+
+      def configure
+        yield configuration
+      end
+    end
   end
 end
 

--- a/lib/view_component/form/configuration.rb
+++ b/lib/view_component/form/configuration.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  module Form
+    class Configuration
+      attr_accessor :parent_component
+
+      def initialize
+        @parent_component = "ViewComponent::Base"
+      end
+    end
+  end
+end

--- a/spec/internal/app/components/application_form_component.rb
+++ b/spec/internal/app/components/application_form_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ApplicationFormComponent < ViewComponent::Base
+end

--- a/spec/internal/config/initializers/view_component_form.rb
+++ b/spec/internal/config/initializers/view_component_form.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+ViewComponent::Form.configure do |config|
+  config.parent_component = "ApplicationFormComponent"
+end

--- a/spec/view_component/form/base_component_spec.rb
+++ b/spec/view_component/form/base_component_spec.rb
@@ -46,4 +46,12 @@ RSpec.describe ViewComponent::Form::BaseComponent, type: :component do
       it { expect(component.object_errors?).to be(false) }
     end
   end
+
+  describe "parent_component" do
+    subject { described_class }
+
+    context "without configured parent_component" do
+      it { is_expected.to be < ViewComponent::Base }
+    end
+  end
 end

--- a/spec/view_component/form/builder_spec.rb
+++ b/spec/view_component/form/builder_spec.rb
@@ -192,4 +192,12 @@ RSpec.describe ViewComponent::Form::Builder, type: :builder do
       it { expect(builder.send(:validation_context)).to eq(:create) }
     end
   end
+
+  describe "base component parent" do
+    subject(:field) { described_class.new(object_name, object, template, options).send(:component_klass, :text_field) }
+
+    it "is configured via initializer" do
+      expect(field.ancestors).to include(ApplicationFormComponent)
+    end
+  end
 end

--- a/spec/view_component/form/configuration_spec.rb
+++ b/spec/view_component/form/configuration_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.describe ViewComponent::Form::Configuration do
+  subject(:configuration) { described_class.new }
+
+  describe "defaults" do
+    it do
+      expect(configuration).to have_attributes(parent_component: "ViewComponent::Base")
+    end
+  end
+end

--- a/spec/view_component/form_spec.rb
+++ b/spec/view_component/form_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe ViewComponent::Form do
     expect(ViewComponent::Form::VERSION).not_to be_nil
   end
 
+  it "is configurable" do
+    expect { |block| described_class.configure(&block) }.to yield_with_args(ViewComponent::Form::Configuration)
+  end
+
   if ENV.fetch("VIEW_COMPONENT_FORM_USE_ACTIONTEXT", "false") == "true"
     it "loads ActionText" do
       expect(defined?(ActionView::Helpers::Tags::ActionText)).to eq("constant")


### PR DESCRIPTION
- Closes https://github.com/pantographe/view_component-form/issues/159

## What

- Adds a configuration object singleton to `ViewComponent::Form`
- Adds configuration option `parent_component` which all `ViewComponent::Form` components inherit from, and defaults to `ViewComponent::Base`

## Why

So that one can define shared logic without having to use concerns or building their own components that don't inherit from their `ViewComponent::Form` component counterpart.

As an example, let's say I'd like to use the [heroicon](https://github.com/bharget/heroicon) gem to add icons to my fields, I can do that easily by defining my own `ApplicationFormComponent`

```rb
class ApplicationFormComponent < ViewComponent::Base
  include Heroicon::Engine.helpers
end
```

or, if I'm using Tailwind, I could use [tailwind_merge](https://github.com/gjtorikian/tailwind_merge) to merge HTML classes to avoid conflicts, etc.