### PR TITLE
Add lookup_chain customizability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added parent_component configuration for field components (#160)
 - Added Ruby 3.3 support (#164)
+- Add `lookup_chain` customizability (#162)
 
 ### Removed
 - Drop Ruby 2.7 support (#164)

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ Development of this gem is sponsored by:
 
 ## Compatibility
 
-> [!WARNING]
-> **This is an early release, and the API is subject to change until `v1.0.0`.**
+> [!WARNING] > **This is an early release, and the API is subject to change until `v1.0.0`.**
 
 This gem is tested on:
 
@@ -35,6 +34,26 @@ end
 | Attribute                   | Purpose                                               | Default                 |
 | --------------------------- | ----------------------------------------------------- | ----------------------- |
 | `parent_component` (string) | Parent class for all `ViewComponent::Form` components | `"ViewComponent::Base"` |
+
+#### Configuring component lookup
+
+`ViewComponent::Form` will automatically infer the component class with a `Component` suffix. You can customize the lookup using the `lookup_chain`:
+
+```rb
+# config/initializers/vcf.rb
+
+ViewComponent::Form.configure do |config|
+  without_component_suffix = lambda do |component_name, namespaces: []|
+    namespaces.lazy.map do |namespace|
+      "#{namespace}::#{component_name.to_s.camelize}".safe_constantize
+    end.find(&:itself)
+  end
+
+  config.lookup_chain.prepend(without_component_suffix)
+end
+```
+
+`ViewComponent::Form` will iterate through the `lookup_chain` until a value is returned. By using `prepend` we can fallback on the default `ViewComponent::Form` lookup.
 
 ## Usage
 

--- a/lib/view_component/form/configuration.rb
+++ b/lib/view_component/form/configuration.rb
@@ -3,10 +3,17 @@
 module ViewComponent
   module Form
     class Configuration
-      attr_accessor :parent_component
+      attr_accessor :parent_component, :lookup_chain
 
       def initialize
         @parent_component = "ViewComponent::Base"
+        @lookup_chain = [
+          lambda do |component_name, namespaces: []|
+            namespaces.lazy.map do |namespace|
+              "#{namespace}::#{component_name.to_s.camelize}Component".safe_constantize
+            end.find(&:itself)
+          end
+        ]
       end
     end
   end

--- a/lib/view_component/form/renderer.rb
+++ b/lib/view_component/form/renderer.rb
@@ -52,9 +52,9 @@ module ViewComponent
 
       def component_klass(component_name)
         @__component_klass_cache[component_name] ||= begin
-          component_klass = self.class.lookup_namespaces.filter_map do |namespace|
-            "#{namespace}::#{component_name.to_s.camelize}Component".safe_constantize || false
-          end.first
+          component_klass = ViewComponent::Form.configuration.lookup_chain.lazy.map do |lookup|
+            lookup.call(component_name, namespaces: lookup_namespaces)
+          end.find(&:itself)
 
           unless component_klass.is_a?(Class) && component_klass < ViewComponent::Base
             raise NotImplementedComponentError, "Component named #{component_name} doesn't exist " \

--- a/spec/internal/app/components/form/text_field.rb
+++ b/spec/internal/app/components/form/text_field.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Form
+  class TextField < ViewComponent::Form::LabelComponent
+    def call
+      "my custom text_field"
+    end
+  end
+end

--- a/spec/view_component/form/configuration_spec.rb
+++ b/spec/view_component/form/configuration_spec.rb
@@ -7,5 +7,31 @@ RSpec.describe ViewComponent::Form::Configuration do
     it do
       expect(configuration).to have_attributes(parent_component: "ViewComponent::Base")
     end
+
+    describe "#lookup_chain" do
+      subject(:lookup_chain) { described_class.new.lookup_chain }
+
+      it "by default implements one lookup lambda" do
+        expect(lookup_chain.length).to be(1)
+      end
+
+      it "uses Component suffix" do
+        expect(
+          lookup_chain.first.call(:text_field, namespaces: [ViewComponent::Form])
+        ).to be(ViewComponent::Form::TextFieldComponent)
+      end
+
+      it "finds the first klass that exists when given a list of namespaces" do # rubocop:disable RSpec/ExampleLength
+        expect(
+          lookup_chain.first.call(
+            :text_field,
+            namespaces: [
+              Form,
+              ViewComponent::Form
+            ]
+          )
+        ).to be(Form::TextFieldComponent)
+      end
+    end
   end
 end


### PR DESCRIPTION
- Closes https://github.com/pantographe/view_component-form/issues/80

Adds configuration to determine how components are found, so one wouldn't need to use the `Component` suffix in their components.

Added documentation to the README.md to configure this option