### PR TITLE
Update README.md to fix a minor formatting for a warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Development of this gem is sponsored by:
 
 ## Compatibility
 
-> [!WARNING] > **This is an early release, and the API is subject to change until `v1.0.0`.**
+> [!WARNING]
+> **This is an early release, and the API is subject to change until `v1.0.0`.**
 
 This gem is tested on:
 


### PR DESCRIPTION
Fixed formatting for the warning in the readme.

**Before:**

<img width="690" alt="image" src="https://github.com/user-attachments/assets/28fedb29-6245-489c-a951-ffb56347b6ff">

**After:**

<img width="584" alt="image" src="https://github.com/user-attachments/assets/a8ac067b-a791-4924-844e-ac95b0ed8f2f">

