### PR TITLE
Handle form object being `false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-Nothing yet
+### Fixed
+- Fix `object_errors` when `object` is `false` (#173)
 
 ## [0.2.8] - 2024-08-20
 ### Added

--- a/app/components/view_component/form/base_component.rb
+++ b/app/components/view_component/form/base_component.rb
@@ -12,7 +12,6 @@ module ViewComponent
       attr_reader :form, :object_name, :options
 
       delegate :object, to: :form, allow_nil: true
-      delegate :errors, to: :object, prefix: true, allow_nil: true
 
       def initialize(form, object_name, options = {})
         @form = form
@@ -28,6 +27,12 @@ module ViewComponent
         return false unless object
 
         object.errors.any?
+      end
+
+      def object_errors
+        return nil unless object
+
+        object.errors
       end
 
       def html_class

--- a/spec/view_component/form/field_component_spec.rb
+++ b/spec/view_component/form/field_component_spec.rb
@@ -87,6 +87,12 @@ RSpec.describe ViewComponent::Form::FieldComponent, type: :component do
 
       it { expect(component.method_errors?).to be(false) }
     end
+
+    context "with false" do
+      let(:object) { false }
+
+      it { expect(component.method_errors?).to be(false) }
+    end
   end
 
   describe "#value" do


### PR DESCRIPTION
As of rails 7.2 a form's object defaults to `false` rather than `nil`, breaking any of the methods in this library that eventually call `object_errors`. This change expands `object_errors` to handle the new default value for `object`, returning `nil` as one would expect.

Rails PR reference: https://github.com/rails/rails/pull/49943