### PR TITLE
Fix: Rename text_area helper to textarea for Rails 8 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Drop Ruby 3.0 support (#186)
 - Drop Rails 6.1 support (#186)
+### Fixed
+- Add `text_area` alias to `textarea` helper to follow Rails 8.0 change (#181)
 
 ## [0.2.9] - 2024-11-09
 ### Added

--- a/README.md
+++ b/README.md
@@ -358,9 +358,9 @@ The following helpers are currently supported by `ViewComponent::Form`.
 
 ### `ActionView::Helpers::FormBuilder`
 
-**Supported:** `button` `check_box` `collection_check_boxes` `collection_radio_buttons` `collection_select` `color_field` `date_field` `date_select` `datetime_field` `datetime_local_field` `datetime_select` `email_field` `fields` `fields_for` `file_field` `field_id` `grouped_collection_select` `hidden_field` `month_field` `number_field` `password_field` `phone_field` `radio_button` `range_field` `search_field` `select` `submit` `telephone_field` `textarea` `text_field` `time_field` `time_select` `time_zone_select` `to_model` `to_partial_path` `url_field` `week_field` `weekday_select`
+**Supported:** `button` `check_box` `collection_check_boxes` `collection_radio_buttons` `collection_select` `color_field` `date_field` `date_select` `datetime_field` `datetime_local_field` `datetime_select` `email_field` `fields` `fields_for` `file_field` `field_id` `grouped_collection_select` `hidden_field` `month_field` `number_field` `password_field` `phone_field` `radio_button` `range_field` `search_field` `select` `submit` `telephone_field` `textarea` (formerly `text_area` before Rails 8) `text_field` `time_field` `time_select` `time_zone_select` `to_model` `to_partial_path` `url_field` `week_field` `weekday_select`
 
-**Partially supported:** `label` (blocks not supported) `rich_textarea` (untested)
+**Partially supported:** `label` (blocks not supported) `rich_textarea` (formerly`rich_text_area` before Rails 8) (untested)
 
 **Unsupported for now:** `field_name`
 

--- a/README.md
+++ b/README.md
@@ -358,9 +358,9 @@ The following helpers are currently supported by `ViewComponent::Form`.
 
 ### `ActionView::Helpers::FormBuilder`
 
-**Supported:** `button` `check_box` `collection_check_boxes` `collection_radio_buttons` `collection_select` `color_field` `date_field` `date_select` `datetime_field` `datetime_local_field` `datetime_select` `email_field` `fields` `fields_for` `file_field` `field_id` `grouped_collection_select` `hidden_field` `month_field` `number_field` `password_field` `phone_field` `radio_button` `range_field` `search_field` `select` `submit` `telephone_field` `text_area` `text_field` `time_field` `time_select` `time_zone_select` `to_model` `to_partial_path` `url_field` `week_field` `weekday_select`
+**Supported:** `button` `check_box` `collection_check_boxes` `collection_radio_buttons` `collection_select` `color_field` `date_field` `date_select` `datetime_field` `datetime_local_field` `datetime_select` `email_field` `fields` `fields_for` `file_field` `field_id` `grouped_collection_select` `hidden_field` `month_field` `number_field` `password_field` `phone_field` `radio_button` `range_field` `search_field` `select` `submit` `telephone_field` `textarea` `text_field` `time_field` `time_select` `time_zone_select` `to_model` `to_partial_path` `url_field` `week_field` `weekday_select`
 
-**Partially supported:** `label` (blocks not supported) `rich_text_area` (untested)
+**Partially supported:** `label` (blocks not supported) `rich_textarea` (untested)
 
 **Unsupported for now:** `field_name`
 

--- a/app/components/view_component/form/rich_text_area_component.rb
+++ b/app/components/view_component/form/rich_text_area_component.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+if Gem::Version.new(Rails::VERSION::STRING) < Gem::Version.new("8.0")
+  module ViewComponent
+    module Form
+      class RichTextAreaComponent < RichTextareaComponent
+      end
+    end
+  end
+end

--- a/app/components/view_component/form/rich_textarea_component.rb
+++ b/app/components/view_component/form/rich_textarea_component.rb
@@ -2,10 +2,14 @@
 
 module ViewComponent
   module Form
-    class RichTextAreaComponent < FieldComponent
+    class RichTextareaComponent < FieldComponent
       if defined?(ActionView::Helpers::Tags::ActionText) # rubocop:disable Style/IfUnlessModifier
         self.tag_klass = ActionView::Helpers::Tags::ActionText
       end
+    end
+
+    if Gem::Version.new(::Rails::VERSION::STRING) < Gem::Version.new("8.0")
+      RichTextAreaComponent = RichTextareaComponent
     end
   end
 end

--- a/app/components/view_component/form/rich_textarea_component.rb
+++ b/app/components/view_component/form/rich_textarea_component.rb
@@ -7,9 +7,5 @@ module ViewComponent
         self.tag_klass = ActionView::Helpers::Tags::ActionText
       end
     end
-
-    if Gem::Version.new(::Rails::VERSION::STRING) < Gem::Version.new("8.0")
-      RichTextAreaComponent = RichTextareaComponent
-    end
   end
 end

--- a/app/components/view_component/form/text_area_component.rb
+++ b/app/components/view_component/form/text_area_component.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module ViewComponent
-  module Form
-    class TextAreaComponent < FieldComponent
-      self.tag_klass = ActionView::Helpers::Tags::TextArea
-    end
-  end
-end

--- a/app/components/view_component/form/text_area_component.rb
+++ b/app/components/view_component/form/text_area_component.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+if Gem::Version.new(Rails::VERSION::STRING) < Gem::Version.new("8.0")
+  module ViewComponent
+    module Form
+      class TextAreaComponent < TextareaComponent
+      end
+    end
+  end
+end

--- a/app/components/view_component/form/textarea_component.rb
+++ b/app/components/view_component/form/textarea_component.rb
@@ -5,7 +5,5 @@ module ViewComponent
     class TextareaComponent < FieldComponent
       self.tag_klass = ActionView::Helpers::Tags::TextArea
     end
-
-    TextAreaComponent = TextareaComponent if Gem::Version.new(::Rails::VERSION::STRING) < Gem::Version.new("8.0")
   end
 end

--- a/app/components/view_component/form/textarea_component.rb
+++ b/app/components/view_component/form/textarea_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  module Form
+    class TextareaComponent < FieldComponent
+      self.tag_klass = ActionView::Helpers::Tags::TextArea
+    end
+
+    TextAreaComponent = TextareaComponent if Gem::Version.new(::Rails::VERSION::STRING) < Gem::Version.new("8.0")
+  end
+end

--- a/lib/view_component/form/helpers/rails.rb
+++ b/lib/view_component/form/helpers/rails.rb
@@ -19,6 +19,7 @@ module ViewComponent
               label
               phone_field
               radio_button
+              textarea
             ]).each do |selector|
               class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
                 def #{selector}(method, options = {}) # def text_field(method, options = {})
@@ -47,6 +48,13 @@ module ViewComponent
           )
         end
         alias datetime_local_field datetime_field
+
+        def textarea(method, options = {})
+          render_component(
+            :text_area, @object_name, method, objectify_options(options)
+          )
+        end
+        alias text_area textarea
 
         def check_box(method, options = {}, checked_value = "1", unchecked_value = "0")
           render_component(

--- a/lib/view_component/form/helpers/rails.rb
+++ b/lib/view_component/form/helpers/rails.rb
@@ -19,7 +19,6 @@ module ViewComponent
               label
               phone_field
               radio_button
-              textarea
             ]).each do |selector|
               class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
                 def #{selector}(method, options = {}) # def text_field(method, options = {})
@@ -48,13 +47,6 @@ module ViewComponent
           )
         end
         alias datetime_local_field datetime_field
-
-        def textarea(method, options = {})
-          render_component(
-            :text_area, @object_name, method, objectify_options(options)
-          )
-        end
-        alias text_area textarea
 
         def check_box(method, options = {}, checked_value = "1", unchecked_value = "0")
           render_component(
@@ -169,9 +161,10 @@ module ViewComponent
         end
 
         if defined?(ActionView::Helpers::Tags::ActionText)
-          def rich_text_area(method, options = {})
+          def rich_textarea(method, options = {})
             render_component(:rich_text_area, @object_name, method, objectify_options(options))
           end
+          alias rich_text_area rich_textarea
         end
       end
       # rubocop:enable Metrics/ModuleLength

--- a/spec/view_component/form/builder_spec.rb
+++ b/spec/view_component/form/builder_spec.rb
@@ -118,6 +118,7 @@ RSpec.describe ViewComponent::Form::Builder, type: :builder do
   it_behaves_like "the default form builder", :number_field, :age
   it_behaves_like "the default form builder", :password_field, :password
   it_behaves_like "the default form builder", :phone_field, :phone
+  it_behaves_like "the default form builder", :telephone_field, :phone
   it_behaves_like "the default form builder", :radio_button, "category", "rails"
   it_behaves_like "the default form builder", :radio_button, "category", "java"
   it_behaves_like "the default form builder", :radio_button, "receive_newsletter", "yes"
@@ -135,6 +136,9 @@ RSpec.describe ViewComponent::Form::Builder, type: :builder do
   end
 
   it_behaves_like "the default form builder", :submit
+  if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new("8.0")
+    it_behaves_like "the default form builder", :textarea, :detail
+  end
   it_behaves_like "the default form builder", :text_area, :detail
   it_behaves_like "the default form builder", :text_field, :name
   it_behaves_like "the default form builder", :time_field, :born_at

--- a/spec/view_component/form/rich_textarea_component_spec.rb
+++ b/spec/view_component/form/rich_textarea_component_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 if defined?(ActionView::Helpers::Tags::ActionText)
-  RSpec.describe ViewComponent::Form::RichTextAreaComponent, type: :component do
+  RSpec.describe ViewComponent::Form::RichTextareaComponent, type: :component do
     let(:object)  { OpenStruct.new }
     let(:form)    { form_with(object) }
     let(:options) { {} }

--- a/spec/view_component/form/textarea_component_spec.rb
+++ b/spec/view_component/form/textarea_component_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe ViewComponent::Form::TextAreaComponent, type: :component do
+RSpec.describe ViewComponent::Form::TextareaComponent, type: :component do
   let(:object)  { OpenStruct.new }
   let(:form)    { form_with(object) }
   let(:options) { {} }


### PR DESCRIPTION
This PR addresses the issue where the `text_area` helper is no longer functional in Rails 8 due to its renaming to `textarea`.

https://github.com/rails/rails/pull/52467