### PR TITLE
Allow 4.x of view_component

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     view_component-form (0.2.11)
       actionview (>= 7.0.0, < 8.1)
       activesupport (>= 7.0.0, < 8.1)
-      view_component (>= 2.34.0, < 4.0)
+      view_component (>= 2.34.0, < 5.0)
       zeitwerk (~> 2.5)
 
 GEM

--- a/view_component-form.gemspec
+++ b/view_component-form.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "actionview", [">= 7.0.0", "< 8.1"]
   spec.add_dependency "activesupport", [">= 7.0.0", "< 8.1"]
-  spec.add_dependency "view_component", [">= 2.34.0", "< 4.0"]
+  spec.add_dependency "view_component", [">= 2.34.0", "< 5.0"]
   spec.add_dependency "zeitwerk", ["~> 2.5"]
 end


### PR DESCRIPTION
This allows using 4.x of view component, everything seems to work with 4.0.1 for me.