### PR TITLE
Fix required association fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Detect required association validators for `_id` and `_ids` fields (#229)
 
 ## [0.3.0] - 2025-10-24
 ### Added

--- a/app/components/view_component/form/field_component.rb
+++ b/app/components/view_component/form/field_component.rb
@@ -98,7 +98,7 @@ module ViewComponent
         @method_validators ||= if object.nil?
                                  []
                                else
-                                 object.class.validators_on(method_name)
+                                 object.class.validators_on(*object_method_names)
                                end
       end
     end

--- a/spec/view_component/form/field_component_spec.rb
+++ b/spec/view_component/form/field_component_spec.rb
@@ -5,11 +5,12 @@ RSpec.describe ViewComponent::Form::FieldComponent, type: :component do
     Class.new do
       include ActiveModel::Model
 
-      attr_accessor :first_name, :last_name, :email, :city
+      attr_accessor :first_name, :last_name, :email, :city, :country_id, :country, :tag_ids, :tags
 
       validates :first_name, presence: true, length: { minimum: 2 }
       validates :email, presence: true, on: :custom_context
       validates :city, presence: true, on: %i[custom_context another_context]
+      validates :country, :tags, presence: true
 
       class << self
         def name
@@ -173,6 +174,18 @@ RSpec.describe ViewComponent::Form::FieldComponent, type: :component do
       let(:method_name) { :last_name }
 
       it { expect(component.required?).to be(false) }
+    end
+
+    context "with a required belongs_to association" do
+      let(:method_name) { :country_id }
+
+      it { expect(component.required?).to be(true) }
+    end
+
+    context "with a required has_many association" do
+      let(:method_name) { :tag_ids }
+
+      it { expect(component.required?).to be(true) }
     end
 
     context "with context" do


### PR DESCRIPTION
Uses `object_method_names` when collecting validators, so required associations are detected for `*_id` and `*_ids` fields.

Adds coverage for `belongs_to` and `has_many`.

Closes #191